### PR TITLE
Implement IPRBProxyStorage interface

### DIFF
--- a/src/PRBProxy.sol
+++ b/src/PRBProxy.sol
@@ -4,36 +4,17 @@ pragma solidity >=0.8.18;
 import { IPRBProxy } from "./interfaces/IPRBProxy.sol";
 import { IPRBProxyPlugin } from "./interfaces/IPRBProxyPlugin.sol";
 import { IPRBProxyRegistry } from "./interfaces/IPRBProxyRegistry.sol";
+import { PRBProxyStorage } from "./PRBProxyStorage.sol";
 
 /// @title PRBProxy
 /// @dev This contract implements the {IPRBProxy} interface.
-contract PRBProxy is IPRBProxy {
+contract PRBProxy is IPRBProxy, PRBProxyStorage {
     /*//////////////////////////////////////////////////////////////////////////
                                      CONSTANTS
     //////////////////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc IPRBProxy
     IPRBProxyRegistry public immutable override registry;
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                   PUBLIC STORAGE
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /// @inheritdoc IPRBProxy
-    address public override owner;
-
-    /// @inheritdoc IPRBProxy
-    uint256 public override minGasReserve;
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                  INTERNAL STORAGE
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Maps plugin methods to plugin implementation.
-    mapping(bytes4 method => IPRBProxyPlugin plugin) internal plugins;
-
-    /// @dev Maps envoys to target contracts to function selectors to boolean flags.
-    mapping(address envoy => mapping(address target => bool permission)) internal permissions;
 
     /*//////////////////////////////////////////////////////////////////////////
                                      CONSTRUCTOR
@@ -83,20 +64,6 @@ contract PRBProxy is IPRBProxy {
 
     /// @dev Called when the call data is empty.
     receive() external payable { }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                              PUBLIC CONSTANT FUNCTIONS
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /// @inheritdoc IPRBProxy
-    function getPermission(address envoy, address target) external view override returns (bool permission) {
-        permission = permissions[envoy][target];
-    }
-
-    /// @inheritdoc IPRBProxy
-    function getPluginForMethod(bytes4 method) external view override returns (IPRBProxyPlugin plugin) {
-        plugin = plugins[method];
-    }
 
     /*/////////////////////////////////////////////////////////////////////////
                             PUBLIC NON-CONSTANT FUNCTIONS

--- a/src/PRBProxyStorage.sol
+++ b/src/PRBProxyStorage.sol
@@ -2,22 +2,20 @@
 pragma solidity >=0.8.18;
 
 import { IPRBProxyPlugin } from "./interfaces/IPRBProxyPlugin.sol";
+import { IPRBProxyStorage } from "./interfaces/IPRBProxyStorage.sol";
 
-/// @notice Abstract contract with the storage layout of the {PRBProxy} contract.
-/// @dev This contract is an exact replica of the storage layout of {PRBProxy}, and it exists so that it can
-/// be inherited in target contracts. However, to avoid overcomplicating the inheritance structure, this is
-/// not inherited by the {PRBProxy} contract itself.
-abstract contract PRBProxyStorage {
+/// @title PRBProxyStorage
+/// @dev This contract implements the {IPRBProxyStorage} interface.
+abstract contract PRBProxyStorage is IPRBProxyStorage {
     /*//////////////////////////////////////////////////////////////////////////
                                    PUBLIC STORAGE
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice The address of the owner account or contract.
-    address public owner;
+    /// @inheritdoc IPRBProxyStorage
+    address public override owner;
 
-    /// @notice How much gas to reserve for running the remainder of the "execute" function after the DELEGATECALL.
-    /// @dev This prevents the proxy from becoming unusable if EVM opcode gas costs change in the future.
-    uint256 public minGasReserve;
+    /// @inheritdoc IPRBProxyStorage
+    uint256 public override minGasReserve;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   INTERNAL STORAGE
@@ -28,4 +26,18 @@ abstract contract PRBProxyStorage {
 
     /// @dev Maps envoys to target contracts to function selectors to boolean flags.
     mapping(address envoy => mapping(address target => bool permission)) internal permissions;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              PUBLIC CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IPRBProxyStorage
+    function getPermission(address envoy, address target) external view override returns (bool permission) {
+        permission = permissions[envoy][target];
+    }
+
+    /// @inheritdoc IPRBProxyStorage
+    function getPluginForMethod(bytes4 method) external view override returns (IPRBProxyPlugin plugin) {
+        plugin = plugins[method];
+    }
 }

--- a/src/PRBProxyStorage.sol
+++ b/src/PRBProxyStorage.sol
@@ -17,27 +17,9 @@ abstract contract PRBProxyStorage is IPRBProxyStorage {
     /// @inheritdoc IPRBProxyStorage
     uint256 public override minGasReserve;
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                  INTERNAL STORAGE
-    //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Maps plugin methods to plugin implementation.
-    mapping(bytes4 method => IPRBProxyPlugin plugin) internal plugins;
-
-    /// @dev Maps envoys to target contracts to function selectors to boolean flags.
-    mapping(address envoy => mapping(address target => bool permission)) internal permissions;
-
-    /*//////////////////////////////////////////////////////////////////////////
-                              PUBLIC CONSTANT FUNCTIONS
-    //////////////////////////////////////////////////////////////////////////*/
+    /// @inheritdoc IPRBProxyStorage
+    mapping(address envoy => mapping(address target => bool permission)) public permissions;
 
     /// @inheritdoc IPRBProxyStorage
-    function getPermission(address envoy, address target) external view override returns (bool permission) {
-        permission = permissions[envoy][target];
-    }
-
-    /// @inheritdoc IPRBProxyStorage
-    function getPluginForMethod(bytes4 method) external view override returns (IPRBProxyPlugin plugin) {
-        plugin = plugins[method];
-    }
+    mapping(bytes4 method => IPRBProxyPlugin plugin) public plugins;
 }

--- a/src/interfaces/IPRBProxy.sol
+++ b/src/interfaces/IPRBProxy.sol
@@ -3,10 +3,11 @@ pragma solidity >=0.8.4;
 
 import { IPRBProxyPlugin } from "./IPRBProxyPlugin.sol";
 import { IPRBProxyRegistry } from "./IPRBProxyRegistry.sol";
+import { IPRBProxyStorage } from "./IPRBProxyStorage.sol";
 
 /// @title IPRBProxy
 /// @notice Proxy contract to compose transactions on owner's behalf.
-interface IPRBProxy {
+interface IPRBProxy is IPRBProxyStorage {
     /*//////////////////////////////////////////////////////////////////////////
                                        ERRORS
     //////////////////////////////////////////////////////////////////////////*/
@@ -43,24 +44,8 @@ interface IPRBProxy {
     event RunPlugin(IPRBProxyPlugin indexed plugin, bytes data, bytes response);
 
     /*//////////////////////////////////////////////////////////////////////////
-                              PUBLIC CONSTANT FUNCTIONS
+                             PUBLIC CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @notice Returns a boolean flag that indicates whether the envoy has permission to call the provided target
-    /// contract.
-    function getPermission(address envoy, address target) external view returns (bool permission);
-
-    /// @notice Returns the address of the plugin installed for the the provided method.
-    /// @dev Returns the zero address if no plugin is installed.
-    /// @param method The signature of the method to make the query for.
-    function getPluginForMethod(bytes4 method) external view returns (IPRBProxyPlugin plugin);
-
-    /// @notice How much gas to reserve for running the remainder of the "execute" function after the DELEGATECALL.
-    /// @dev This prevents the proxy from becoming unusable if EVM opcode gas costs change in the future.
-    function minGasReserve() external view returns (uint256);
-
-    /// @notice The address of the owner account or contract.
-    function owner() external view returns (address);
 
     /// @notice The address of the registry that has deployed this proxy.
     function registry() external view returns (IPRBProxyRegistry);

--- a/src/interfaces/IPRBProxyStorage.sol
+++ b/src/interfaces/IPRBProxyStorage.sol
@@ -2,7 +2,6 @@
 pragma solidity >=0.8.4;
 
 import { IPRBProxyPlugin } from "./IPRBProxyPlugin.sol";
-import { IPRBProxyRegistry } from "./IPRBProxyRegistry.sol";
 
 /// @title IPRBProxyStorage
 /// @dev Storage contract so that it can be inherited in target contracts.
@@ -11,19 +10,19 @@ interface IPRBProxyStorage {
                               PUBLIC CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Returns a boolean flag that indicates whether the envoy has permission to call the provided target
-    /// contract.
-    function getPermission(address envoy, address target) external view returns (bool permission);
-
-    /// @notice Returns the address of the plugin installed for the the provided method.
-    /// @dev Returns the zero address if no plugin is installed.
-    /// @param method The signature of the method to make the query for.
-    function getPluginForMethod(bytes4 method) external view returns (IPRBProxyPlugin plugin);
-
     /// @notice How much gas to reserve for running the remainder of the "execute" function after the DELEGATECALL.
     /// @dev This prevents the proxy from becoming unusable if EVM opcode gas costs change in the future.
     function minGasReserve() external view returns (uint256);
 
     /// @notice The address of the owner account or contract.
     function owner() external view returns (address);
+
+    /// @notice Returns a boolean flag that indicates whether the envoy has permission to call the provided target
+    /// contract.
+    function permissions(address envoy, address target) external view returns (bool permission);
+
+    /// @notice Returns the address of the plugin installed for the the provided method.
+    /// @dev Returns the zero address if no plugin is installed.
+    /// @param method The signature of the method to make the query for.
+    function plugins(bytes4 method) external view returns (IPRBProxyPlugin plugin);
 }

--- a/src/interfaces/IPRBProxyStorage.sol
+++ b/src/interfaces/IPRBProxyStorage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+import { IPRBProxyPlugin } from "./IPRBProxyPlugin.sol";
+import { IPRBProxyRegistry } from "./IPRBProxyRegistry.sol";
+
+/// @title IPRBProxyStorage
+/// @dev Storage contract so that it can be inherited in target contracts.
+interface IPRBProxyStorage {
+    /*//////////////////////////////////////////////////////////////////////////
+                              PUBLIC CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns a boolean flag that indicates whether the envoy has permission to call the provided target
+    /// contract.
+    function getPermission(address envoy, address target) external view returns (bool permission);
+
+    /// @notice Returns the address of the plugin installed for the the provided method.
+    /// @dev Returns the zero address if no plugin is installed.
+    /// @param method The signature of the method to make the query for.
+    function getPluginForMethod(bytes4 method) external view returns (IPRBProxyPlugin plugin);
+
+    /// @notice How much gas to reserve for running the remainder of the "execute" function after the DELEGATECALL.
+    /// @dev This prevents the proxy from becoming unusable if EVM opcode gas costs change in the future.
+    function minGasReserve() external view returns (uint256);
+
+    /// @notice The address of the owner account or contract.
+    function owner() external view returns (address);
+}

--- a/test/helpers/install-plugin/installPlugin.t.sol
+++ b/test/helpers/install-plugin/installPlugin.t.sol
@@ -28,7 +28,7 @@ contract InstallPlugin_Test is Helpers_Test {
         // Assert that every plugin method has been installed.
         bytes4[] memory pluginMethods = plugins.dummy.methodList();
         for (uint256 i = 0; i < pluginMethods.length; ++i) {
-            IPRBProxyPlugin actualPlugin = proxy.getPluginForMethod(pluginMethods[i]);
+            IPRBProxyPlugin actualPlugin = proxy.plugins(pluginMethods[i]);
             IPRBProxyPlugin expectedPlugin = plugins.dummy;
             assertEq(actualPlugin, expectedPlugin, "Plugin method not installed");
         }
@@ -46,7 +46,7 @@ contract InstallPlugin_Test is Helpers_Test {
         // Assert that every plugin method has been installed.
         bytes4[] memory pluginMethods = plugins.dummy.methodList();
         for (uint256 i = 0; i < pluginMethods.length; ++i) {
-            IPRBProxyPlugin actualPlugin = proxy.getPluginForMethod(pluginMethods[i]);
+            IPRBProxyPlugin actualPlugin = proxy.plugins(pluginMethods[i]);
             IPRBProxyPlugin expectedPlugin = plugins.dummy;
             assertEq(actualPlugin, expectedPlugin, "Plugin method not installed");
         }

--- a/test/helpers/set-permission/setPermission.t.sol
+++ b/test/helpers/set-permission/setPermission.t.sol
@@ -7,7 +7,7 @@ contract SetPermission_Test is Helpers_Test {
     /// @dev it should set the permission.
     function test_SetPermission_PermissionNotSet() external {
         setPermission({ envoy: users.envoy, target: address(targets.dummy), permission: true });
-        bool permission = proxy.getPermission({ envoy: users.envoy, target: address(targets.dummy) });
+        bool permission = proxy.permissions({ envoy: users.envoy, target: address(targets.dummy) });
         assertTrue(permission);
     }
 
@@ -19,7 +19,7 @@ contract SetPermission_Test is Helpers_Test {
     /// @dev it should do nothing when re-setting the permission.
     function test_SetPermission_PermissionSet_ResetPermission() external permissionSet {
         setPermission({ envoy: users.envoy, target: address(targets.dummy), permission: true });
-        bool permission = proxy.getPermission({ envoy: users.envoy, target: address(targets.dummy) });
+        bool permission = proxy.permissions({ envoy: users.envoy, target: address(targets.dummy) });
         assertTrue(permission);
     }
 

--- a/test/helpers/uninstall-plugin/uninstallPlugin.t.sol
+++ b/test/helpers/uninstall-plugin/uninstallPlugin.t.sol
@@ -25,7 +25,7 @@ contract UninstallPlugin_Test is Helpers_Test {
         // Assert that every plugin method has been uninstalled.
         bytes4[] memory pluginMethods = plugins.dummy.methodList();
         for (uint256 i = 0; i < pluginMethods.length; ++i) {
-            IPRBProxyPlugin actualPlugin = proxy.getPluginForMethod(pluginMethods[i]);
+            IPRBProxyPlugin actualPlugin = proxy.plugins(pluginMethods[i]);
             IPRBProxyPlugin expectedPlugin = IPRBProxyPlugin(address(0));
             assertEq(actualPlugin, expectedPlugin, "Plugin method installed");
         }
@@ -45,7 +45,7 @@ contract UninstallPlugin_Test is Helpers_Test {
         // Assert that every plugin method has been uninstalled.
         bytes4[] memory pluginMethods = plugins.dummy.methodList();
         for (uint256 i = 0; i < pluginMethods.length; ++i) {
-            IPRBProxyPlugin actualPlugin = proxy.getPluginForMethod(pluginMethods[i]);
+            IPRBProxyPlugin actualPlugin = proxy.plugins(pluginMethods[i]);
             IPRBProxyPlugin expectedPlugin = IPRBProxyPlugin(address(0));
             assertEq(actualPlugin, expectedPlugin, "Plugin method installed");
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,29 +6,29 @@ __metadata:
   cacheKey: 8
 
 "@babel/code-frame@npm:^7.0.0":
-  version: 7.12.13
-  resolution: "@babel/code-frame@npm:7.12.13"
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
   dependencies:
-    "@babel/highlight": ^7.12.13
-  checksum: d0491bb59fb8d7a763cb175c5504818cfd3647321d8eedb9173336d5c47dccce248628ee68b3ed3586c5efc753d8d990ceafe956f707dcf92572a1661b92b1ef
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.12.11":
-  version: 7.12.11
-  resolution: "@babel/helper-validator-identifier@npm:7.12.11"
-  checksum: e604c6bf890704fc46c1ae13bf23afb242b810224ec3403bba67cdbf0d8dabfec4b82123d6dfb18135a0ee3f7f79218583c819363ebb5e04a0a49d8418db7fce
+"@babel/helper-validator-identifier@npm:^7.18.6":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.12.13":
-  version: 7.13.10
-  resolution: "@babel/highlight@npm:7.13.10"
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.12.11
+    "@babel/helper-validator-identifier": ^7.18.6
     chalk: ^2.0.0
     js-tokens: ^4.0.0
-  checksum: 2f33624c8e0947101fd72ca8d2af291cd9560bcb3ed63299e5f95a70e64c2a435922d915ede6760f30ff23942589fe42b962b6b8138f868abaa6f7abd4d4f5e9
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
   languageName: node
   linkType: hard
 
@@ -42,12 +42,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@solidity-parser/parser@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@solidity-parser/parser@npm:0.15.0"
+"@solidity-parser/parser@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@solidity-parser/parser@npm:0.16.0"
   dependencies:
     antlr4ts: ^0.5.0-alpha.4
-  checksum: 19c3a4b0778020c2b73893d19844258dc15eddf2c4959f21ac583fa101a159a859b749b58a4a7af52ccc0daa0eb6fb2b51fdb6e6b4c5d9082e4f06d53c49d04b
+  checksum: 6ccbdab334331a58fde2a739cff76d5a99d836186b7899e8e027266f2af2a4bddc77c9c2abd01307cea6c470345d48edc470049e9672143b73f4aff3c8976183
   languageName: node
   linkType: hard
 
@@ -101,9 +101,9 @@ __metadata:
   linkType: hard
 
 "antlr4@npm:^4.11.0":
-  version: 4.11.0
-  resolution: "antlr4@npm:4.11.0"
-  checksum: 640240640d5fd8fff4f494a20eb8e733ccc96a7e887f34e3ab534b258e2b8fa600cea8b2bea656fa9dac6022b07fc9d6fb2b825da43824c570559bf0fd5b4725
+  version: 4.12.0
+  resolution: "antlr4@npm:4.12.0"
+  checksum: f70a7765e1c44d678abd6500f2d9659a9d64c572e433576bf82b09b38179ce1191327cfd04d848036651989ba887c1a53da2a41a516dfe93d8e78b5d63801624
   languageName: node
   linkType: hard
 
@@ -138,9 +138,9 @@ __metadata:
   linkType: hard
 
 "balanced-match@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "balanced-match@npm:1.0.0"
-  checksum: 9b67bfe558772f40cf743a3469b48b286aecec2ea9fe80c48d74845e53aab1cef524fafedf123a63019b49ac397760573ef5f173f539423061f7217cbb5fbd40
+  version: 1.0.2
+  resolution: "balanced-match@npm:1.0.2"
+  checksum: 9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
   languageName: node
   linkType: hard
 
@@ -154,9 +154,9 @@ __metadata:
   linkType: hard
 
 "buffer-from@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "buffer-from@npm:1.1.1"
-  checksum: ccc53b69736008bff764497367c4d24879ba7122bc619ee499ff47eef3a5b885ca496e87272e7ebffa0bec3804c83f84041c616f6e3318f40624e27c1d80f045
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
   languageName: node
   linkType: hard
 
@@ -228,14 +228,14 @@ __metadata:
   linkType: hard
 
 "cosmiconfig@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "cosmiconfig@npm:8.0.0"
+  version: 8.1.0
+  resolution: "cosmiconfig@npm:8.1.0"
   dependencies:
     import-fresh: ^3.2.1
     js-yaml: ^4.1.0
     parse-json: ^5.0.0
     path-type: ^4.0.0
-  checksum: ff4cdf89ac1ae52e7520816622c21a9e04380d04b82d653f5139ec581aa4f7f29e096d46770bc76c4a63c225367e88a1dfa233ea791669a35101f5f9b972c7d1
+  checksum: 78a1846acc4935ab4d928e3f768ee2ad2fddbec96377935462749206568423ff4757140ac7f2ccd1f547f86309b8448c04b26588848b5a1520f2e9741cdeecf0
   languageName: node
   linkType: hard
 
@@ -300,6 +300,18 @@ __metadata:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
+  languageName: node
+  linkType: hard
+
+"glob@npm:^9.2.0":
+  version: 9.2.1
+  resolution: "glob@npm:9.2.1"
+  dependencies:
+    fs.realpath: ^1.0.0
+    minimatch: ^7.4.1
+    minipass: ^4.2.4
+    path-scurry: ^1.6.1
+  checksum: ef9b1c32491e6b532bdd0d2abcc3c9f48e83446609e11285869156982fc5a756dfbaa6f59f797712343bd1e22500ac15708692806633653fde4ef67c85e2aab7
   languageName: node
   linkType: hard
 
@@ -405,9 +417,9 @@ __metadata:
   linkType: hard
 
 "lines-and-columns@npm:^1.1.6":
-  version: 1.1.6
-  resolution: "lines-and-columns@npm:1.1.6"
-  checksum: 198a5436b1fa5cf703bae719c01c686b076f0ad7e1aafd95a58d626cabff302dc0414822126f2f80b58a8c3d66cda8a7b6da064f27130f87e1d3506d6dfd0d68
+  version: 1.2.4
+  resolution: "lines-and-columns@npm:1.2.4"
+  checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
   languageName: node
   linkType: hard
 
@@ -425,12 +437,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^7.14.1":
+  version: 7.18.3
+  resolution: "lru-cache@npm:7.18.3"
+  checksum: e550d772384709deea3f141af34b6d4fa392e2e418c1498c078de0ee63670f1f46f5eee746e8ef7e69e1c895af0d4224e62ee33e66a543a14763b0f2e74c1356
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^5.0.1":
   version: 5.1.6
   resolution: "minimatch@npm:5.1.6"
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^7.4.1":
+  version: 7.4.2
+  resolution: "minimatch@npm:7.4.2"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 9e341b04e69d5ab03e4206dcb61c8a158e3b8709628bf5e1a4eaa9f3b72c0ba925e24ad959b1f6ce6835caa5a927131d5087fae6836b69e7d99d7d5e63ef0bd8
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^4.0.2, minipass@npm:^4.2.4":
+  version: 4.2.4
+  resolution: "minipass@npm:4.2.4"
+  checksum: c664f2ae4401408d1e7a6e4f50aca45f87b1b0634bc9261136df5c378e313e77355765f73f59c4a5abcadcdf43d83fcd3eb14e4a7cdcce8e36508e2290345753
   languageName: node
   linkType: hard
 
@@ -464,6 +499,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "path-scurry@npm:1.6.1"
+  dependencies:
+    lru-cache: ^7.14.1
+    minipass: ^4.0.2
+  checksum: 7ba57e823cb7bb879669a4e5e05a283cde1bb9e81b6d806b2609f8d8026d0aef08f4b655b17fc86b21c9c32807851bba95ca715db5ab0605fb13c7a3e9172e42
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -488,9 +533,9 @@ __metadata:
   linkType: hard
 
 "punycode@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "punycode@npm:2.1.1"
-  checksum: 823bf443c6dd14f669984dea25757b37993f67e8d94698996064035edd43bed8a5a17a9f12e439c2b35df1078c6bec05a6c86e336209eb1061e8025c481168e8
+  version: 2.3.0
+  resolution: "punycode@npm:2.3.0"
+  checksum: 39f760e09a2a3bbfe8f5287cf733ecdad69d6af2fe6f97ca95f24b8921858b91e9ea3c9eeec6e08cede96181b3bb33f95c6ffd8c77e63986508aa2e8159fa200
   languageName: node
   linkType: hard
 
@@ -509,11 +554,13 @@ __metadata:
   linkType: hard
 
 "rimraf@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "rimraf@npm:4.1.2"
+  version: 4.3.1
+  resolution: "rimraf@npm:4.3.1"
+  dependencies:
+    glob: ^9.2.0
   bin:
     rimraf: dist/cjs/src/bin.js
-  checksum: 480b8147fd9bcbef3ac118f88a7b1169c3872977a3411a0c84df838bfc30e175a394c0db6f9619fc8b8a886a18c6d779d5e74f380a0075ecc710afaf81b3f50c
+  checksum: d5893862a1e96cde610599ae76e338a709252667408d38bffa07cd24891a840a95957c4bb7178a9b0d3b6141e3b1bea20b9ba4b4f99d8c9edc492723e7b125ec
   languageName: node
   linkType: hard
 
@@ -538,10 +585,10 @@ __metadata:
   linkType: hard
 
 "solhint@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "solhint@npm:3.4.0"
+  version: 3.4.1
+  resolution: "solhint@npm:3.4.1"
   dependencies:
-    "@solidity-parser/parser": ^0.15.0
+    "@solidity-parser/parser": ^0.16.0
     ajv: ^6.12.6
     antlr4: ^4.11.0
     ast-parents: ^0.0.1
@@ -564,17 +611,17 @@ __metadata:
       optional: true
   bin:
     solhint: solhint.js
-  checksum: b99ce230e6429275e1b63a0f4e41449d8a366b31d14c034f47b42bf3062b03574ac10d375ff28f4b389f796fb3f42db99dabc701fa56dddaba310dc59004806f
+  checksum: 4f81b5bac126c6b07ac36be887c0b120263b5628671d8433c5a20ed9f8168ec6224a706456f1b625c0b9e15143427d229eff497dfea94eca398b63b727c8f7bc
   languageName: node
   linkType: hard
 
 "source-map-support@npm:^0.5.16":
-  version: 0.5.19
-  resolution: "source-map-support@npm:0.5.19"
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
   dependencies:
     buffer-from: ^1.0.0
     source-map: ^0.6.0
-  checksum: c72802fdba9cb62b92baef18cc14cc4047608b77f0353e6c36dd993444149a466a2845332c5540d4a6630957254f0f68f4ef5a0120c33d2e83974c51a05afbac
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The purpose of this PR is to remove duplicated code in `PRBProxy` contract.

Changes made: 
- Added `IPRBProxyStorage` interface
- Inherit `IPRBProxyStorage` in `IPRBProxy`
- Inherit `PRBProxyStorage` in `PRBProxy`
- Moved public constant functions from `PRBProxy` to `PRBProxyStorage`
- Removed internal and public storage from `PRBProxy`

