### PR TITLE
feat: abstract contract for plugin

### DIFF
--- a/src/PRBProxy.sol
+++ b/src/PRBProxy.sol
@@ -34,8 +34,8 @@ contract PRBProxy is
                                      CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Constructs the proxy by fetching the constructor parameters from the registry.
-    /// @dev This is implemented like this to make it easy to precompute the CREATE2 address of the proxy.
+    /// @notice Constructs the proxy by fetching the params from the registry.
+    /// @dev This is implemented like this so that the proxy's CREATE2 address doesn't depend on the constructor params.
     constructor() {
         minGasReserve = 5000;
         registry = IPRBProxyRegistry(msg.sender);
@@ -52,7 +52,7 @@ contract PRBProxy is
         // Check if the function signature exists in the installed plugins mapping.
         IPRBProxyPlugin plugin = plugins[msg.sig];
         if (address(plugin) == address(0)) {
-            revert PRBProxy_PluginNotInstalledForMethod(msg.sender, msg.sig);
+            revert PRBProxy_PluginNotInstalledForMethod({ caller: msg.sender, selector: msg.sig });
         }
 
         // Delegate call to the plugin.

--- a/src/abstracts/PRBProxyPlugin.sol
+++ b/src/abstracts/PRBProxyPlugin.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.18;
+
+import { IPRBProxyPlugin } from "../interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyStorage } from "./PRBProxyStorage.sol";
+
+/// @title PRBProxyPlugin
+/// @dev This is meant to be inherited by plugins. See the documentation in {IPRBProxyPlugin}.
+abstract contract PRBProxyPlugin is IPRBProxyPlugin, PRBProxyStorage { }

--- a/src/abstracts/PRBProxyStorage.sol
+++ b/src/abstracts/PRBProxyStorage.sol
@@ -5,7 +5,7 @@ import { IPRBProxyPlugin } from "../interfaces/IPRBProxyPlugin.sol";
 import { IPRBProxyStorage } from "../interfaces/IPRBProxyStorage.sol";
 
 /// @title PRBProxyStorage
-/// @dev This is meant to be inherited by target contracts. See the full documentation in {IPRBProxyStorage}.
+/// @dev This is meant to be inherited by plugins and targets. See the documentation in {IPRBProxyStorage}.
 abstract contract PRBProxyStorage is IPRBProxyStorage {
     /// @inheritdoc IPRBProxyStorage
     address public override owner;

--- a/src/interfaces/IPRBProxyPlugin.sol
+++ b/src/interfaces/IPRBProxyPlugin.sol
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
+import { IPRBProxyStorage } from "./IPRBProxyStorage.sol";
+
 /// @title IPRBProxyPlugin
-/// @notice Interface for the plugins that can be installed on a proxy.
+/// @notice Interface for plugin contracts that can be installed on a proxy.
 /// @dev Plugins are contracts that enable the proxy to interact with and respond to calls from other contracts. These
 /// plugins are run in the proxy's fallback function.
-interface IPRBProxyPlugin {
+///
+/// A couple of notes about this interface:
+///
+/// - It is not meant to be inherited by plugins. Instead, plugins should inherit from {PRBProxyPlugin}.
+/// - It should be used only for casting addresses to the interface type.
+/// - It inherits from {IPRBProxyStorage} to enable plugins to access the proxy's storage.
+interface IPRBProxyPlugin is IPRBProxyStorage {
     /// @notice Enumerates the methods implemented by the plugin.
     /// @dev These methods can be installed and uninstalled.
     ///

--- a/test/mocks/plugins/PluginChangeOwner.sol
+++ b/test/mocks/plugins/PluginChangeOwner.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
 import { TargetChangeOwner } from "../targets/TargetChangeOwner.sol";
 
-contract PluginChangeOwner is IPRBProxyPlugin, TargetChangeOwner {
+contract PluginChangeOwner is PRBProxyPlugin, TargetChangeOwner {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](1);
         methods[0] = this.changeIt.selector;

--- a/test/mocks/plugins/PluginDummy.sol
+++ b/test/mocks/plugins/PluginDummy.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
 import { TargetDummy } from "../targets/TargetDummy.sol";
 
-contract PluginDummy is IPRBProxyPlugin, TargetDummy {
+contract PluginDummy is PRBProxyPlugin, TargetDummy {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](2);
         methods[0] = this.foo.selector;

--- a/test/mocks/plugins/PluginEcho.sol
+++ b/test/mocks/plugins/PluginEcho.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
 import { TargetEcho } from "../targets/TargetEcho.sol";
 
-contract PluginEcho is IPRBProxyPlugin, TargetEcho {
+contract PluginEcho is PRBProxyPlugin, TargetEcho {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](9);
 

--- a/test/mocks/plugins/PluginEmpty.sol
+++ b/test/mocks/plugins/PluginEmpty.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
-contract PluginEmpty is IPRBProxyPlugin {
+contract PluginEmpty is PRBProxyPlugin {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](0);
         return methods;

--- a/test/mocks/plugins/PluginPanic.sol
+++ b/test/mocks/plugins/PluginPanic.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 import { TargetPanic } from "../targets/TargetPanic.sol";
 
-contract PluginPanic is IPRBProxyPlugin, TargetPanic {
+contract PluginPanic is PRBProxyPlugin, TargetPanic {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](4);
 

--- a/test/mocks/plugins/PluginReverter.sol
+++ b/test/mocks/plugins/PluginReverter.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
 import { TargetReverter } from "../targets/TargetReverter.sol";
 
-contract PluginReverter is IPRBProxyPlugin, TargetReverter {
+contract PluginReverter is PRBProxyPlugin, TargetReverter {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](5);
 

--- a/test/mocks/plugins/PluginSelfDestructer.sol
+++ b/test/mocks/plugins/PluginSelfDestructer.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-import { IPRBProxyPlugin } from "../../../src/interfaces/IPRBProxyPlugin.sol";
+import { PRBProxyPlugin } from "../../../src/abstracts/PRBProxyPlugin.sol";
 
 import { TargetSelfDestructer } from "../targets/TargetSelfDestructer.sol";
 
-contract PluginSelfDestructer is IPRBProxyPlugin, TargetSelfDestructer {
+contract PluginSelfDestructer is PRBProxyPlugin, TargetSelfDestructer {
     function methodList() external pure override returns (bytes4[] memory) {
         bytes4[] memory methods = new bytes4[](1);
         methods[0] = this.destroyMe.selector;

--- a/test/mocks/targets/TargetChangeOwner.sol
+++ b/test/mocks/targets/TargetChangeOwner.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetChangeOwner {
-    address public owner;
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
 
+contract TargetChangeOwner is PRBProxyStorage {
     function changeIt() external {
         owner = address(1729);
     }

--- a/test/mocks/targets/TargetDummy.sol
+++ b/test/mocks/targets/TargetDummy.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetDummy {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetDummy is PRBProxyStorage {
     function foo() external pure returns (string memory) {
         return "foo";
     }

--- a/test/mocks/targets/TargetDummyWithFallback.sol
+++ b/test/mocks/targets/TargetDummyWithFallback.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18 <0.9.0;
 
-contract TargetDummyWithFallback {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetDummyWithFallback is PRBProxyStorage {
     event LogFallback();
 
     fallback() external payable {

--- a/test/mocks/targets/TargetEcho.sol
+++ b/test/mocks/targets/TargetEcho.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetEcho {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetEcho is PRBProxyStorage {
     struct SomeStruct {
         uint256 foo;
         uint256 bar;

--- a/test/mocks/targets/TargetMinGasReserve.sol
+++ b/test/mocks/targets/TargetMinGasReserve.sol
@@ -1,11 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-/// @dev This works because the storage layout is exactly the same as in {PRBProxy}.
-contract TargetMinGasReserve {
-    address public owner;
-    uint256 public minGasReserve;
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
 
+contract TargetMinGasReserve is PRBProxyStorage {
     function setMinGasReserve(uint256 newMinGasReserve) external {
         minGasReserve = newMinGasReserve;
     }

--- a/test/mocks/targets/TargetPanic.sol
+++ b/test/mocks/targets/TargetPanic.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetPanic {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetPanic is PRBProxyStorage {
     function failedAssertion() external pure {
         assert(false);
     }

--- a/test/mocks/targets/TargetPayable.sol
+++ b/test/mocks/targets/TargetPayable.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18 <0.9.0;
 
-contract TargetPayable {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetPayable is PRBProxyStorage {
     function revertLackPayableModifier() external payable returns (uint256) {
         return 0;
     }

--- a/test/mocks/targets/TargetReverter.sol
+++ b/test/mocks/targets/TargetReverter.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetReverter {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetReverter is PRBProxyStorage {
     error SomeError();
 
     function withNothing() external pure {

--- a/test/mocks/targets/TargetSelfDestructer.sol
+++ b/test/mocks/targets/TargetSelfDestructer.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
-contract TargetSelfDestructer {
+import { PRBProxyStorage } from "../../../src/abstracts/PRBProxyStorage.sol";
+
+contract TargetSelfDestructer is PRBProxyStorage {
     function destroyMe(address payable recipient) external {
         selfdestruct(recipient);
     }


### PR DESCRIPTION
I would have added "N inherited components" comments in the `PRBProxyPlugin` abstract, but this bug in `forge fmt` has prevented me from doing so:

https://github.com/foundry-rs/foundry/issues/4872