### PR TITLE
refactor: rename deployer to broadcaster

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.19 <0.9.0;
+pragma solidity >=0.8.19 <=0.9.0;
 
 import { Script } from "forge-std/Script.sol";
 
@@ -10,19 +10,31 @@ abstract contract BaseScript is Script {
     /// @dev Needed for the deterministic deployments.
     bytes32 internal constant ZERO_SALT = bytes32(0);
 
-    /// @dev The address of the contract deployer.
-    address internal deployer;
+    /// @dev The address of the transaction broadcaster.
+    address internal broadcaster;
 
-    /// @dev Used to derive the deployer's address.
+    /// @dev Used to derive the broadcaster's address if $ETH_FROM is not defined.
     string internal mnemonic;
 
+    /// @dev Initializes the transaction broadcaster like this:
+    ///
+    /// - If $ETH_FROM is defined, use it.
+    /// - Otherwise, derive the broadcaster address from $MNEMONIC.
+    /// - If $MNEMONIC is not defined, default to a test mnemonic.
+    ///
+    /// The use case for $ETH_FROM is to specify the broadcaster key and its address via the command line.
     constructor() {
-        mnemonic = vm.envOr("MNEMONIC", TEST_MNEMONIC);
-        (deployer,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        address from = vm.envOr({ name: "ETH_FROM", defaultValue: address(0) });
+        if (from != address(0)) {
+            broadcaster = from;
+        } else {
+            mnemonic = vm.envOr({ name: "MNEMONIC", defaultValue: TEST_MNEMONIC });
+            (broadcaster,) = deriveRememberKey({ mnemonic: mnemonic, index: 0 });
+        }
     }
 
-    modifier broadcaster() {
-        vm.startBroadcast(deployer);
+    modifier broadcast() {
+        vm.startBroadcast(broadcaster);
         _;
         vm.stopBroadcast();
     }

--- a/script/DeployDeterministicRegistry.s.sol
+++ b/script/DeployDeterministicRegistry.s.sol
@@ -10,7 +10,7 @@ import { BaseScript } from "./Base.s.sol";
 contract DeployDeterministicRegistry is BaseScript {
     /// @dev The presence of the salt instructs Forge to deploy contracts via this deterministic CREATE2 factory:
     /// https://github.com/Arachnid/deterministic-deployment-proxy
-    function run(uint256 create2Salt) public virtual broadcaster returns (PRBProxyRegistry registry) {
+    function run(uint256 create2Salt) public virtual broadcast returns (PRBProxyRegistry registry) {
         registry = new PRBProxyRegistry{ salt: bytes32(create2Salt) }();
     }
 }

--- a/script/DeployProxyViaRegistry.s.sol
+++ b/script/DeployProxyViaRegistry.s.sol
@@ -6,9 +6,9 @@ import { IPRBProxyRegistry } from "../src/interfaces/IPRBProxyRegistry.sol";
 
 import { BaseScript } from "./Base.s.sol";
 
-/// @notice Deploys an instance of {PRBProxy} via the registry. The owner of the proxy will be `deployer`.
+/// @notice Deploys an instance of {PRBProxy} via the registry. The owner of the proxy will be `broadcaster`.
 contract DeployProxyViaRegistry is BaseScript {
-    function run(IPRBProxyRegistry registry) public virtual broadcaster returns (IPRBProxy proxy) {
+    function run(IPRBProxyRegistry registry) public virtual broadcast returns (IPRBProxy proxy) {
         proxy = registry.deploy();
     }
 }

--- a/script/DeployRegistry.s.sol
+++ b/script/DeployRegistry.s.sol
@@ -6,7 +6,7 @@ import { PRBProxyRegistry } from "../src/PRBProxyRegistry.sol";
 import { BaseScript } from "./Base.s.sol";
 
 contract DeployRegistry is BaseScript {
-    function run() public virtual broadcaster returns (PRBProxyRegistry registry) {
+    function run() public virtual broadcast returns (PRBProxyRegistry registry) {
         registry = new PRBProxyRegistry();
     }
 }

--- a/script/SetPermission.s.sol
+++ b/script/SetPermission.s.sol
@@ -7,8 +7,8 @@ import { BaseScript } from "./Base.s.sol";
 
 /// @notice Permits an envoy to delegate call to a target contract.
 contract SetPermission is BaseScript {
-    function run(IPRBProxyRegistry registry, address target, bool permission) public broadcaster {
-        address envoy = vm.addr(vm.deriveKey(mnemonic, 1));
+    function run(IPRBProxyRegistry registry, address target, bool permission) public broadcast {
+        address envoy = vm.addr(vm.deriveKey({ mnemonic: mnemonic, index: 1 }));
         registry.setPermission({ envoy: envoy, target: target, permission: permission });
     }
 }


### PR DESCRIPTION
This PR does two things:

- Rename `deployer` to `broadcaster` in `BaseScript` (not all scripts deploy contracts)
- Allows the user to pass the broadcaster key and address via the command line (e.g. by passing `--ledger` and setting the `ETH_FROM` environment variable)

I needed to make this refactor to be able to deploy using Ledger.